### PR TITLE
fix: resolve YAML syntax error in version-bump workflow heredoc

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -202,15 +202,10 @@ jobs:
 
           # Create CHANGELOG.md if it doesn't exist
           if [ ! -f CHANGELOG.md ]; then
-            cat > CHANGELOG.md << 'CHANGELOG_EOF'
-# Changelog
-
-All notable changes to Hugo Syndicate will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-CHANGELOG_EOF
+            printf '# Changelog\n\n' > CHANGELOG.md
+            printf 'All notable changes to Hugo Syndicate will be documented in this file.\n\n' >> CHANGELOG.md
+            printf 'The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),\n' >> CHANGELOG.md
+            printf 'and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n\n' >> CHANGELOG.md
           fi
 
           # Add new entry after the header


### PR DESCRIPTION
## Summary
Fixed YAML syntax error for version-bump.yml by replacing heredoc with printf statements

## Changes
- Replaced heredoc syntax for CHANGELOG.md creation with printf statements
- This avoids GitHub Actions YAML parser issues with certain content in heredocs

## Fix Details
The error was caused by GitHub Actions having trouble parsing the heredoc content, specifically the line "All notable changes to Hugo
Syndicate will be documented in this file." Using printf statements instead of heredoc resolves this issue while maintaining the same
functionality.