### PR TITLE
fix: disable body-max-line-length in commitlint for semantic-release compatibility

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -2,6 +2,7 @@
   "extends": ["@commitlint/config-conventional"],
   "rules": {
     "subject-case": [2, "never", ["upper-case", "pascal-case", "start-case"]],
-    "header-max-length": [2, "always", 100]
+    "header-max-length": [2, "always", 100],
+    "body-max-line-length": [0, "always", 100]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to Hugo Syndicate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0-alpha] - 2025-07-07
+<!-- Semantic-release will auto-generate entries above this line -->
 
-### Added
+## Pre-release History
+
+### [0.1.0-alpha] - 2025-07-07
+
+#### Added
 
 - Initial release of Hugo Syndicate
 - Full API integration for dev.to and Qiita with create/update/delete operations
@@ -25,20 +29,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-language URL support
 - Hugo permalink pattern support
 
-### Features
+#### Features
 
 - Environment-based configuration
 - Simple error handling and recovery
 - File permission validation
 - Automatic retry on failures
 
-### Technical
+#### Technical
 
 - Node.js 16+ compatibility
 - Zero runtime dependencies (only build-time)
 - NPM package ready
 
-### Alpha Notice
+#### Alpha Notice
 
 This is an alpha release. While functional, it may contain bugs and the API may change in future versions. Use in production at your own risk.
 


### PR DESCRIPTION
## Summary

Disable body-max-line-length in commitlint for semantic-release compatibility

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test improvement
- [x] Build / CI improvement

## Testing

- [x] Do tests pass locally with (`npm test`)?
- [x] Added/updated tests as needed?
- [x] Have you manually tested changes?

## Checklist

You've confirm that:

- [x] You've reviewed my own code
- [x] You've updated documentation as needed
- [x] All your commits follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Related Issues (If any...)

N/A

## Notes

<!-- Please add any additional context, notes or comments as needed -->
